### PR TITLE
Handle cname host with changing IP address by forcing nginx to reload DNS

### DIFF
--- a/snippets/server-proxy.conf
+++ b/snippets/server-proxy.conf
@@ -9,7 +9,8 @@ server {
   include resty-server-https.conf;
 
   location / {
-    proxy_pass http://$SERVER_ENDPOINT;
+    set $server_upstream http://$SERVER_ENDPOINT;
+    proxy_pass $server_upstream;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
When proxying to a CNAME host with changing IP address (for instance an AWS ELB) this trick makes nginx check the DNS for the domain instead of just resolving it on startup. Without this the server would suddenly start sending 502 Bad gateway and errors in the logs like this when the host changes IP:
```
[error] 23#23: *110174 no live upstreams while connecting to upstream, client: 123.123.123.123
[error] 23#23: *110162 upstream timed out (110: Operation timed out) while connecting to upstream, client: 123.123.123.123
```
The fix was taken from this article: https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/