### PR TITLE
Use specific openresty version instead of unknown docker tag version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine-fat
+FROM openresty/openresty:1.19.9.1-7-alpine-fat
 
 # allowed domains should be lua match pattern
 ENV DIFFIE_HELLMAN='' \


### PR DESCRIPTION
Instead of using the latest tag (bad practice), use a specific versioned tag instead. This lets us know exactly which version of
openresty is being used.