### PR TITLE
update ssl.conf to use headers-more-nginx-module included with openresty

### DIFF
--- a/snippets/ssl.conf
+++ b/snippets/ssl.conf
@@ -13,6 +13,6 @@ ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 ssl_prefer_server_ciphers on;
 
-# HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+# HSTS (uses headers-more-nginx-module included with openresty) (15768000 seconds = 6 months)
 # uncomment if you are sure you'll never drop HTTPS support
-# add_header Strict-Transport-Security max-age=15768000;
+# more_set_headers Strict-Transport-Security max-age=15768000;


### PR DESCRIPTION
The current ssl.conf references the `ngx_http_headers_module` which is not included with openresty.

We can instead use the `headers-more-nginx-module` which ships with openresty, enabling STS to be activated simply by uncommenting the line, which makes for an easier and more surgical activation of this feature.